### PR TITLE
Update reactive energy sensor

### DIFF
--- a/custom_components/emu_m_bus_center/sensor.py
+++ b/custom_components/emu_m_bus_center/sensor.py
@@ -228,7 +228,7 @@ class EmuReactiveEnergySensor(EmuBaseSensor):
     Sadly, varh and kvarh do not exist in HA.
     """
 
-    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
     _attr_device_class = SensorDeviceClass.ENERGY
     _attr_icon = "mdi:lightning-bolt-outline"
 

--- a/custom_components/emu_m_bus_center/sensor.py
+++ b/custom_components/emu_m_bus_center/sensor.py
@@ -20,6 +20,7 @@ from homeassistant.const import (
     UnitOfEnergy,
     UnitOfFrequency,
     UnitOfPower,
+    UnitOfReactiveEnergy,
     UnitOfReactivePower,
     UnitOfVolume,
 )
@@ -223,11 +224,9 @@ class EmuReactivePowerSensor(EmuBaseSensor):
 
 
 class EmuReactiveEnergySensor(EmuBaseSensor):
-    """Sensor for reactive energy in kVArh.
+    """Sensor for reactive energy in kVArh."""
 
-    Sadly, varh and kvarh do not exist in HA.
-    """
-
+    _attr_native_unit_of_measurement = UnitOfReactiveEnergy.KILO_VOLT_AMPERE_REACTIVE_HOUR
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
     _attr_device_class = SensorDeviceClass.ENERGY
     _attr_icon = "mdi:lightning-bolt-outline"

--- a/custom_components/emu_m_bus_center/sensor.py
+++ b/custom_components/emu_m_bus_center/sensor.py
@@ -228,7 +228,7 @@ class EmuReactiveEnergySensor(EmuBaseSensor):
 
     _attr_native_unit_of_measurement = UnitOfReactiveEnergy.KILO_VOLT_AMPERE_REACTIVE_HOUR
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
-    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_device_class = SensorDeviceClass.REACTIVE_ENERGY
     _attr_icon = "mdi:lightning-bolt-outline"
 
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "Emu M-Bus Center",
   "hacs": "1.6.0",
-  "homeassistant": "0.7.4",
+  "homeassistant": "2025.6.0",
   "render_readme": true
 }


### PR DESCRIPTION
giving them the correct state class, device class and unit of measurement

this is only possible because of https://github.com/home-assistant/core/pull/143941 and therefore lifts the minimum HA version to 2025.6.0