### PR TITLE
handle unreachable mbus center

### DIFF
--- a/custom_components/emu_m_bus_center/__init__.py
+++ b/custom_components/emu_m_bus_center/__init__.py
@@ -8,6 +8,7 @@ import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 
 from .const import DOMAIN
 from .device_types.devices import generic_sensor_deserializer
@@ -41,6 +42,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     if not connection_info.get("found_center"):
         _LOGGER.error("__init__ did not find a center")
+        raise ConfigEntryNotReady(
+            "Could not communicate with M-Bus Center at %s", config_entry.data["ip"]
+        )
 
     if not connection_info.get("found_all_sensors"):
         _LOGGER.error("__init__ did not find all sensors")

--- a/custom_components/emu_m_bus_center/emu_client.py
+++ b/custom_components/emu_m_bus_center/emu_client.py
@@ -44,7 +44,7 @@ class EmuApiClient:
                     text = await main_page_response.text()
                     if "emu_logo_128px" in text:
                         result["found_center"] = True
-            except aiohttp.ClientError as ce:
+            except (TimeoutError, aiohttp.ClientError) as ce:
                 _LOGGER.error(
                     "Validate Connection could not reach M-Bus Center on %s: %s",
                     self._ip,


### PR DESCRIPTION
So homeassistant retries the connection if the m-bus center is unavailable during startup

fixes #404 